### PR TITLE
Invoke configure-mirrors role in base

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -8,6 +8,7 @@
     - start-zuul-console
     - validate-host
     - prepare-workspace
+    - configure-mirrors
 
 # If there is a registered role (as constructed from project name) try to
 # generate secret-id and leave it at well-known location. The job is then


### PR DESCRIPTION
There are lots of cases where job may want to install additional
packages. This requires proper setup of packages infrastructure on the
test resources and at least invoking `apt update` in Debian based VMs
(what is not done in the image itself).

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
