### PR TITLE
Add support for larger nodeset

### DIFF
--- a/zuul.d/container-jobs.yaml
+++ b/zuul.d/container-jobs.yaml
@@ -6,6 +6,7 @@
       Build container image(s) in SCS using podman
 
       .. include:: ../../playbooks/container-image/README.rst
+    nodeset: ubuntu-jammy-large
 
 - job:
     name: scs-upload-container-image

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -19,10 +19,7 @@
     timeout: 1800
     vars:
       vault_cloud_secret_path: "clouds/wavestack_zuul_logs"
-    nodeset:
-      nodes:
-        - name: ubuntu-jammy
-          label: ubuntu-jammy
+    nodeset: ubuntu-jammy
 
 - job:
     name: base-extra-logs

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -1,0 +1,12 @@
+---
+- nodeset:
+    name: ubuntu-jammy
+    nodes:
+      - name: ubuntu-jammy
+        label: ubuntu-jammy
+
+- nodeset:
+    name: ubuntu-jammy-large
+    nodes:
+      - name: ubuntu-jammy
+        label: ubuntu-jammy-large


### PR DESCRIPTION
- split nodesets into separate definition file
- switch image building job to the larger nodeset

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
