### PR TITLE
Add scs-tox-linters job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -32,6 +32,13 @@
     post-run:
       - playbooks/base/post-fetch.yaml
 
+- job:
+    name: scs-tox-liters
+    parent: tox-linters
+    description:
+      run `tox -e linters` in a fedora pod
+    nodeset: pod-fedora-39
+
 #- semaphore:
 #    name: semaphore-openstack-access
 #    max: 3

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -10,3 +10,9 @@
     nodes:
       - name: ubuntu-jammy
         label: ubuntu-jammy-large
+
+- nodeset:
+    name: pod-fedora-39
+    nodes:
+      - name: fedora-pod
+        label: pod-fedora-39


### PR DESCRIPTION
Add new job that executes `tox -e linters` in a pod. For this add new
nodeset with the fedora39.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
