### PR TITLE
Move vault vars under zuul_vault

### DIFF
--- a/playbooks/openstack/pre.yaml
+++ b/playbooks/openstack/pre.yaml
@@ -3,12 +3,13 @@
   hosts: localhost
   vars:
     vault_addr: "{{ zuul_vault_addr }}"
-    vault_token: "{{ lookup('file', zuul_base_vault_token_path) }}"
     vault_secret_dest: "{{ zuul.executor.work_root }}/.approle-secret"
     vault_token_dest: "{{ zuul.executor.work_root }}/.approle-token"
+    vault_role_name: "{{ zuul_vault.vault_role_name }}"
 
   roles:
     - role: create-vault-approle-token
+      vault_role_id: "{{ zuul_vault.vault_role_id }}"
       vault_wrapping_token_id: "{{ lookup('file', vault_secret_dest) }}"
 
 - name: OpenStack access configuration file

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -53,5 +53,6 @@
     vars:
       cloud: "gx-scs-zuul"
       vault_cloud_secret_path: "clouds/gx_scs_k8s_e2e"
-      vault_role_name: "zuul_scs_sovereigncloudstack_zuul-scs-jobs"
-      vault_role_id: "bc5d3801-3c73-acd0-1e63-de5ed0041a07"
+      zuul_vault:
+        vault_role_name: "zuul_scs_sovereigncloudstack_zuul-scs-jobs"
+        vault_role_id: "bc5d3801-3c73-acd0-1e63-de5ed0041a07"


### PR DESCRIPTION
base jobs only generates secret for the job if zuul_vault var is set.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
