### PR TITLE
Use zuul-scs-jobs role for access jobs

### DIFF
--- a/playbooks/openstack/pre.yaml
+++ b/playbooks/openstack/pre.yaml
@@ -8,6 +8,10 @@
     vault_role_name: "{{ zuul_vault.vault_role_name }}"
 
   roles:
+    # Create a new AppRole secret for the zuul-scs-jobs AppRole
+    - role: create-vault-approle-secret
+
+    # Unwrap secret and exchange it for the Vault access token
     - role: create-vault-approle-token
       vault_role_id: "{{ zuul_vault.vault_role_id }}"
       vault_wrapping_token_id: "{{ lookup('file', vault_secret_dest) }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -50,6 +50,8 @@
     post-run: playbooks/openstack/post.yaml
     semaphores:
       - semaphore-openstack-access
+    allowed-projects:
+      - SovereignCloudStack/zuul-config
     vars:
       cloud: "gx-scs-zuul"
       vault_cloud_secret_path: "clouds/gx_scs_k8s_e2e"


### PR DESCRIPTION
The base jobs generates wrapper vault approle secret for the role
containing the project name. In the case of access jobs we cannot do it
this way and should use the global project name.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
