### PR TITLE
Gather artifacts for jobs without change

### DIFF
--- a/playbooks/base/post.yaml
+++ b/playbooks/base/post.yaml
@@ -21,6 +21,28 @@
         name: merge-output-to-logs
       when: ansible_user_dir is defined
 
+    # This is a copy from the merge-output-to-logs which does not copy
+    # artifacts for jobs without a change. While it makes sense to some
+    # extend there are cases where it is desired (fetching artifacts of 
+    # periodic jobs).
+    - name: Move artifacts and docs to logs dir
+      when: zuul.change is not defined
+      delegate_to: localhost
+      shell: |
+        if [ -n "$(find {{ zuul.executor.work_root }}/{{ zj_item }} -mindepth 1)" ] ; then
+          # Only create target directory if it is needed.
+          # Do not fail if it is already there.
+          mkdir -p {{ zuul.executor.log_root }}/{{ zj_item }}
+          # Leave the original directory behind so that other roles
+          # operating on the interface directories can simply no-op.
+          mv -f {{ zuul.executor.work_root }}/{{ zj_item }}/* {{ zuul.executor.log_root }}/{{ zj_item }}
+        fi
+      loop:
+        - artifacts
+      loop_control:
+        loop_var: zj_item
+      run_once: true
+
 - hosts: all
   ignore_errors: yes
   tasks:


### PR DESCRIPTION
merge-output-to-logs role is not copying artifacts for jobs without a
change. We need those i.e. to keep artifacts of the periodic
certification verification jobs.